### PR TITLE
`DS-05` feat: event publish and handler implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,65 @@
-# Disx - Kotlin Distributed Event Framework
+# Disx
 
-🚀 **분산환경을 경험해보고 싶지만 시스템 구축은 귀찮은 개발자들을 위한 프레임워크**
+> Distributed Event Streaming Framework / Supports Kafka and transactional outbox pattern.
 
-## ✨ 주요 기능
+![jdk 17](https://img.shields.io/badge/minimum_jdk-17-orange?labelColor=black&style=flat-square) ![spring-boot](https://img.shields.io/badge/spring--boot-3.2.x-brightgreen?labelColor=black&style=flat-square)    
+![kotlin](https://img.shields.io/badge/kotlin-1.9.21-purple?labelColor=black&style=flat-square) ![kafka](https://img.shields.io/badge/-apache--kafka-000000?style=flat-square&logo=Apache%20Kafka&logoColor=white)
 
-- 🎯 **이벤트 기반 아키텍처**: RabbitMQ 기반 안정적인 이벤트 처리
-- 🔒 **분산 락**: Redis 기반 다양한 락 타입 지원
-- 🔄 **Saga 패턴**: Orchestration/Choreography 지원
-- 📊 **모니터링**: Prometheus, Grafana 연동
-- 🛡️ **안정성**: 자동 재시도, DLQ, 멱등성 보장
-- ⚡ **고성능**: 비동기 처리, 백프레셔 제어
+**High-throughput event processing** with guaranteed delivery using transactional outbox pattern.
 
-## 🚀 빠른 시작
+Disx is a distributed event streaming framework that provides the following features:
 
-### 1. 의존성 추가
+1. **Transactional Outbox Pattern** - Automatically ensures reliable event publishing with database transactions.
+2. **Kafka Integration** - Native support for Apache Kafka with Spring Kafka.
+3. **Event-Driven Architecture** - Domain events with automatic serialization and routing.
+4. **Coroutines Support** - Async event handling with Kotlin coroutines.
+5. **Spring Boot Auto-Configuration** - Zero-configuration setup with `@EnableDisx`.
+6. **At-Least-Once Delivery** - Guarantees message delivery with retry mechanisms.
+7. **AOP-based Event Interception** - Automatic outbox pattern implementation.
+
+## Table of Contents
+
+- [Download](#download)
+- [How to use](#how-to-use)
+    - [Basic Setup](#basic-setup)
+    - [Configuration](#configuration)
+    - [Creating Domain Events](#creating-domain-events)
+    - [Publishing Events](#publishing-events)
+    - [Event Handlers](#event-handlers)
+    - [Outbox Pattern](#outbox-pattern)
+- [Repository Implementation](#repository-implementation)
+- [Testing](#testing)
+
+## Download
+
+### Gradle
 
 ```kotlin
 dependencies {
-    implementation("io.github.disx:disx:1.0.0")
+    implementation("org.sandbox:disx:0.0.9")
 }
 ```
 
-### 2. 프레임워크 활성화
+### Maven
+
+```xml
+
+<dependency>
+    <groupId>org.sandbox</groupId>
+    <artifactId>disx</artifactId>
+    <version>0.0.9</version>
+</dependency>
+```
+
+## How to use
+
+### Basic Setup
+
+Enable Disx in your Spring Boot application:
 
 ```kotlin
-@SpringBootApplication
 @EnableDisx
+@SpringBootApplication
 class Application
 
 fun main(args: Array<String>) {
@@ -33,44 +67,349 @@ fun main(args: Array<String>) {
 }
 ```
 
-### 3. 첫 번째 이벤트
+### Configuration
+
+Configure Disx using application properties:
+
+```yaml
+disx:
+  enabled: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    partitions: 3
+    replicas: 1
+  outbox:
+    enabled: true
+    polling-interval: 1000
+    batch-size: 100
+
+spring:
+  kafka:
+    producer:
+      acks: all
+      retries: 3
+```
+
+#### Properties
+
+| Property                       | Default          | Description                   |
+|--------------------------------|------------------|-------------------------------|
+| `disx.enabled`                 | `true`           | Enable/disable Disx framework |
+| `disx.kafka.bootstrap-servers` | `localhost:9092` | Kafka broker addresses        |
+| `disx.kafka.partitions`        | `3`              | Default partitions for topics |
+| `disx.kafka.replicas`          | `1`              | Default replication factor    |
+| `disx.outbox.enabled`          | `true`           | Enable outbox pattern         |
+| `disx.outbox.polling-interval` | `1000`           | Polling interval in ms        |
+| `disx.outbox.batch-size`       | `100`            | Batch size for processing     |
+
+### Creating Domain Events
+
+Define your domain events by extending `BaseDomainEvent`:
 
 ```kotlin
-@DomainEvent(name = "order.created")
+@DomainEvent(
+    name = "order.created",
+    exchange = "disx.events",
+    routingKey = "order.created",
+    priority = 1
+)
 data class OrderCreatedEvent(
-    val orderId: String,
     val customerId: String,
-    val amount: BigDecimal
-) : BaseDomainEvent(orderId)
+    val amount: BigDecimal,
+    val items: List<OrderItem>
+) : BaseDomainEvent(
+    aggregateId = "order-${UUID.randomUUID()}",
+    eventId = UUID.randomUUID().toString(),
+    occurredAt = Instant.now()
+)
+```
 
+The `@DomainEvent` annotation supports:
+
+- `name`: Event name identifier
+- `exchange`: Message exchange (default: "disx.events")
+- `routingKey`: Routing key for message routing
+- `priority`: Event priority (default: 0)
+- `persistent`: Message persistence (default: true)
+
+### Publishing Events
+
+#### Synchronous Publishing
+
+```kotlin
 @Service
 class OrderService(private val eventBus: EventBus) {
+
+    @Transactional
     fun createOrder(customerId: String, amount: BigDecimal): String {
         val orderId = UUID.randomUUID().toString()
-        eventBus.publish(OrderCreatedEvent(orderId, customerId, amount))
-        return orderId
-    }
-}
 
-@Component
-class NotificationService {
-    @EventHandler(events = [OrderCreatedEvent::class])
-    fun sendNotification(event: OrderCreatedEvent) {
-        println("📧 주문 확인 이메일 발송: ${event.orderId}")
+        // Business logic
+        val order = saveOrder(customerId, amount)
+
+        // Publish event - automatically intercepted by outbox pattern
+        eventBus.publish(OrderCreatedEvent(customerId, amount))
+
+        return orderId
     }
 }
 ```
 
-## 📖 문서
+#### Asynchronous Publishing
 
-- [사용자 가이드](https://disx.io/docs)
-- [API 레퍼런스](https://disx.io/api)
-- [예제 프로젝트](https://github.com/disx/examples)
+```kotlin
+@Service
+class PaymentService(private val eventBus: EventBus) {
 
-## 🤝 기여하기
+    suspend fun processPayment(orderId: String, amount: BigDecimal) {
+        // Process payment logic
 
-버그 리포트, 기능 요청, Pull Request를 환영합니다!
+        // Publish async event
+        eventBus.publishAsync(
+            PaymentProcessedEvent(orderId, amount, "credit-card")
+        )
+    }
+}
+```
 
-## 📄 라이선스
+#### Batch Publishing
 
-Apache License 2.0
+```kotlin
+@Service
+class BulkOrderService(private val eventBus: EventBus) {
+
+    @Transactional
+    fun processBulkOrders(orders: List<CreateOrderRequest>) {
+        val events = orders.map { request ->
+            val order = createOrder(request)
+            OrderCreatedEvent(order.customerId, order.amount)
+        }
+
+        // Batch publish for better performance
+        eventBus.publishBatch(events)
+
+        // Or async batch
+        // eventBus.publishBatchAsync(events)
+    }
+}
+```
+
+### Event Handlers
+
+Create event handlers by implementing the `EventHandler` interface:
+
+```kotlin
+@Component
+class OrderEventHandler : EventHandler<OrderCreatedEvent> {
+
+    override suspend fun handle(event: OrderCreatedEvent) {
+        // Process the order created event
+        println("Processing order: ${event.aggregateId}")
+
+        // Send notification
+        notificationService.sendOrderConfirmation(event.customerId)
+
+        // Update inventory
+        inventoryService.reserveItems(event.items)
+    }
+
+    override fun getEventType(): Class<OrderCreatedEvent> {
+        return OrderCreatedEvent::class.java
+    }
+}
+```
+
+### Outbox Pattern
+
+The outbox pattern is automatically implemented through AOP. When you publish an event within a transaction:
+
+1. **Event Interception**: The `OutboxEventPublisher` intercepts all `EventBus.publish*()` calls
+2. **Transaction Detection**: Checks if a Spring transaction is active
+3. **Event Storage**: If transaction exists, converts to Spring event and stores in outbox
+4. **Background Publishing**: `OutboxKafkaPublisher` polls the outbox and publishes to Kafka
+
+The `OutboxEvent` class represents events in the outbox:
+
+```kotlin
+data class OutboxEvent(
+    val id: String,
+    val aggregateId: String,
+    val eventType: String,
+    val eventData: String,
+    val status: OutboxStatus = OutboxStatus.PENDING,
+    val createdAt: Instant = Instant.now(),
+    val processedAt: Instant? = null,
+    val retryCount: Int = 0
+)
+
+enum class OutboxStatus {
+    PENDING,
+    PROCESSED,
+    FAILED
+}
+```
+
+## Repository Implementation
+
+You need to implement the `OutboxRepository` interface for your persistence layer:
+
+```kotlin
+@Repository
+class JpaOutboxRepository(
+    private val jpaRepository: OutboxEventJpaRepository
+) : OutboxRepository {
+
+    override fun save(event: OutboxEvent) {
+        jpaRepository.save(event.toEntity())
+    }
+
+    override fun findPendingEvents(limit: Int): List<OutboxEvent> {
+        return jpaRepository.findByStatusOrderByCreatedAt(
+            OutboxStatus.PENDING,
+            PageRequest.of(0, limit)
+        ).map { it.toDomain() }
+    }
+
+    override fun updateStatus(eventId: String, status: OutboxStatus) {
+        jpaRepository.updateStatus(eventId, status, Instant.now())
+    }
+
+    override fun getLastProcessedEventId(): String? {
+        return jpaRepository.findFirstByStatusOrderByProcessedAtDesc(
+            OutboxStatus.PROCESSED
+        )?.id
+    }
+
+    override fun findPendingEventsAfterId(lastEventId: String?, limit: Int): List<OutboxEvent> {
+        return if (lastEventId != null) {
+            jpaRepository.findPendingEventsAfterId(lastEventId, limit)
+        } else {
+            jpaRepository.findByStatusOrderByCreatedAt(
+                OutboxStatus.PENDING,
+                PageRequest.of(0, limit)
+            )
+        }.map { it.toDomain() }
+    }
+}
+```
+
+### Database Schema
+
+Example schema for the outbox table:
+
+```sql
+CREATE TABLE outbox_events
+(
+    id           VARCHAR(255) PRIMARY KEY,
+    aggregate_id VARCHAR(255) NOT NULL,
+    event_type   VARCHAR(500) NOT NULL,
+    event_data   TEXT         NOT NULL,
+    status       VARCHAR(50)  NOT NULL DEFAULT 'PENDING',
+    created_at   TIMESTAMP    NOT NULL DEFAULT NOW(),
+    processed_at TIMESTAMP NULL,
+    retry_count  INTEGER      NOT NULL DEFAULT 0,
+
+    INDEX        idx_status_created (status, created_at),
+    INDEX        idx_aggregate_id (aggregate_id),
+    INDEX        idx_processed_at (processed_at)
+);
+```
+
+## Testing
+
+### Unit Testing Events
+
+```kotlin
+class OrderCreatedEventTest {
+
+    @Test
+    fun `should create order event with correct properties`() {
+        val customerId = "customer-123"
+        val amount = BigDecimal("99.99")
+
+        val event = OrderCreatedEvent(customerId, amount, emptyList())
+
+        assertThat(event.customerId).isEqualTo(customerId)
+        assertThat(event.amount).isEqualTo(amount)
+        assertThat(event.aggregateId).isNotEmpty()
+        assertThat(event.eventId).isNotEmpty()
+        assertThat(event.occurredAt).isBeforeOrEqualTo(Instant.now())
+    }
+
+    @Test
+    fun `events with same eventId should be equal`() {
+        val eventId = "same-event-id"
+        val event1 = OrderCreatedEvent("customer1", BigDecimal.TEN, emptyList())
+            .copy(eventId = eventId)
+        val event2 = OrderCreatedEvent("customer2", BigDecimal.ONE, emptyList())
+            .copy(eventId = eventId)
+
+        assertThat(event1).isEqualTo(event2)
+        assertThat(event1.hashCode()).isEqualTo(event2.hashCode())
+    }
+}
+```
+
+### Integration Testing
+
+```kotlin
+@SpringBootTest
+@TestPropertySource(
+    properties = [
+        "disx.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",
+        "disx.outbox.enabled=true"
+    ]
+)
+@EmbeddedKafka(partitions = 1, topics = ["test-events"])
+class DisxIntegrationTest {
+
+    @Autowired
+    private lateinit var eventBus: EventBus
+
+    @Autowired
+    private lateinit var outboxRepository: OutboxRepository
+
+    @Test
+    @Transactional
+    fun `should save event to outbox when published within transaction`() {
+        val event = OrderCreatedEvent("customer-123", BigDecimal("99.99"), emptyList())
+
+        eventBus.publish(event)
+
+        val outboxEvents = outboxRepository.findPendingEvents()
+        assertThat(outboxEvents).hasSize(1)
+        assertThat(outboxEvents.first().eventType).contains("OrderCreatedEvent")
+    }
+}
+```
+
+## Architecture
+
+### Event Flow
+
+1. **Business Logic** → Calls `eventBus.publish(event)` within `@Transactional` method
+2. **AOP Interception** → `OutboxEventPublisher` intercepts the call
+3. **Transaction Check** → Verifies if Spring transaction is active
+4. **Event Storage** → Converts to Spring event, handled by `OutboxService`
+5. **Outbox Persistence** → Event saved to database within same transaction
+6. **Background Publishing** → `OutboxKafkaPublisher` polls and publishes to Kafka
+7. **Status Update** → Event status updated to PROCESSED/FAILED
+
+### Key Components
+
+- **`@EnableDisx`** - Enables auto-configuration
+- **`EventBus`** - Core interface for publishing events
+- **`BaseDomainEvent`** - Base class for all domain events
+- **`@DomainEvent`** - Annotation for event metadata
+- **`OutboxEventPublisher`** - AOP aspect for transaction interception
+- **`OutboxService`** - Handles Spring events and outbox storage
+- **`OutboxKafkaPublisher`** - Background publisher to Kafka
+- **`OutboxRepository`** - Interface for outbox persistence
+
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/src/main/kotlin/org/sandbox/disx/core/events/BaseDomainEvent.kt
+++ b/src/main/kotlin/org/sandbox/disx/core/events/BaseDomainEvent.kt
@@ -11,19 +11,19 @@ abstract class BaseDomainEvent(
 ) {
 
     /**
-     * 이벤트 타입을 반환합니다.
+     * Returns the event type.
      */
     fun getEventType(): String = this::class.simpleName ?: "UnknownEvent"
 
     /**
-     * 이벤트를 문자열로 표현합니다.
+     * Returns a string representation of the event.
      */
     override fun toString(): String {
         return "${getEventType()}(aggregateId=$aggregateId, eventId=$eventId, occurredAt=$occurredAt)"
     }
 
     /**
-     * 이벤트의 동등성을 확인합니다.
+     * Checks the equality of events.
      */
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -32,7 +32,7 @@ abstract class BaseDomainEvent(
     }
 
     /**
-     * 이벤트의 해시 코드를 반환합니다.
+     * Returns the hash code of the event.
      */
     override fun hashCode(): Int {
         return eventId.hashCode()

--- a/src/main/kotlin/org/sandbox/disx/core/events/BaseDomainEvent.kt
+++ b/src/main/kotlin/org/sandbox/disx/core/events/BaseDomainEvent.kt
@@ -1,25 +1,40 @@
 package org.sandbox.disx.core.events
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Instant
 import java.util.*
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+
 abstract class BaseDomainEvent(
     val aggregateId: String,
     val eventId: String = UUID.randomUUID().toString(),
-    val occurredAt: Instant = Instant.now(),
+    val occurredAt: Instant = Instant.now()
 ) {
 
+    /**
+     * 이벤트 타입을 반환합니다.
+     */
+    fun getEventType(): String = this::class.simpleName ?: "UnknownEvent"
+
+    /**
+     * 이벤트를 문자열로 표현합니다.
+     */
+    override fun toString(): String {
+        return "${getEventType()}(aggregateId=$aggregateId, eventId=$eventId, occurredAt=$occurredAt)"
+    }
+
+    /**
+     * 이벤트의 동등성을 확인합니다.
+     */
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BaseDomainEvent) return false
         return eventId == other.eventId
     }
 
-    override fun hashCode(): Int = eventId.hashCode()
-
-    override fun toString(): String {
-        return "${this::class.simpleName}(eventId='$eventId', aggregateId='$aggregateId')"
+    /**
+     * 이벤트의 해시 코드를 반환합니다.
+     */
+    override fun hashCode(): Int {
+        return eventId.hashCode()
     }
 }

--- a/src/main/kotlin/org/sandbox/disx/core/events/EventBus.kt
+++ b/src/main/kotlin/org/sandbox/disx/core/events/EventBus.kt
@@ -1,24 +1,27 @@
 package org.sandbox.disx.core.events
 
+/**
+ * 이벤트 버스 인터페이스
+ */
 interface EventBus {
-
+    
     /**
-     * 단일 이벤트를 동기적으로 발행합니다.
+     * 이벤트를 동기적으로 발행합니다.
      */
     fun <T : BaseDomainEvent> publish(event: T)
-
+    
     /**
-     * 단일 이벤트를 비동기적으로 발행합니다.
+     * 이벤트를 비동기적으로 발행합니다.
      */
     suspend fun <T : BaseDomainEvent> publishAsync(event: T)
-
+    
     /**
-     * 여러 이벤트를 배치로 발행합니다.
+     * 여러 이벤트를 동기적으로 배치 발행합니다.
      */
     fun <T : BaseDomainEvent> publishBatch(events: List<T>)
-
+    
     /**
-     * 여러 이벤트를 비동기 배치로 발행합니다.
+     * 여러 이벤트를 비동기적으로 배치 발행합니다.
      */
     suspend fun <T : BaseDomainEvent> publishBatchAsync(events: List<T>)
 }

--- a/src/main/kotlin/org/sandbox/disx/core/events/EventBus.kt
+++ b/src/main/kotlin/org/sandbox/disx/core/events/EventBus.kt
@@ -1,27 +1,27 @@
 package org.sandbox.disx.core.events
 
 /**
- * 이벤트 버스 인터페이스
+ * Event bus interface
  */
 interface EventBus {
     
     /**
-     * 이벤트를 동기적으로 발행합니다.
+     * Publishes an event synchronously.
      */
     fun <T : BaseDomainEvent> publish(event: T)
     
     /**
-     * 이벤트를 비동기적으로 발행합니다.
+     * Publishes an event asynchronously.
      */
     suspend fun <T : BaseDomainEvent> publishAsync(event: T)
     
     /**
-     * 여러 이벤트를 동기적으로 배치 발행합니다.
+     * Publishes multiple events synchronously in batch.
      */
     fun <T : BaseDomainEvent> publishBatch(events: List<T>)
     
     /**
-     * 여러 이벤트를 비동기적으로 배치 발행합니다.
+     * Publishes multiple events asynchronously in batch.
      */
     suspend fun <T : BaseDomainEvent> publishBatchAsync(events: List<T>)
 }

--- a/src/main/kotlin/org/sandbox/disx/core/events/EventHandler.kt
+++ b/src/main/kotlin/org/sandbox/disx/core/events/EventHandler.kt
@@ -3,14 +3,14 @@ package org.sandbox.disx.core.events
 interface EventHandler<T : BaseDomainEvent> {
 
     /**
-     * 이벤트를 처리합니다.
+     * Process the event.
      *
-     * @param event 처리할 이벤트
+     * @param event Event to process
      */
     suspend fun handle(event: T)
 
     /**
-     * 이 핸들러가 처리할 수 있는 이벤트 타입을 반환합니다.
+     * Returns the event type this handler can process.
      */
     fun getEventType(): Class<T>
 }

--- a/src/main/kotlin/org/sandbox/disx/core/events/EventHandler.kt
+++ b/src/main/kotlin/org/sandbox/disx/core/events/EventHandler.kt
@@ -1,0 +1,16 @@
+package org.sandbox.disx.core.events
+
+interface EventHandler<T : BaseDomainEvent> {
+
+    /**
+     * 이벤트를 처리합니다.
+     *
+     * @param event 처리할 이벤트
+     */
+    suspend fun handle(event: T)
+
+    /**
+     * 이 핸들러가 처리할 수 있는 이벤트 타입을 반환합니다.
+     */
+    fun getEventType(): Class<T>
+}

--- a/src/main/kotlin/org/sandbox/disx/outbox/OutboxEventPublisher.kt
+++ b/src/main/kotlin/org/sandbox/disx/outbox/OutboxEventPublisher.kt
@@ -19,12 +19,12 @@ class OutboxEventPublisher(
         val event = joinPoint.args[0] as? BaseDomainEvent
 
         if (event != null && isTransactionActive()) {
-            // 스프링 이벤트로 발행
+            // Publish as Spring event
             applicationContext.publishEvent(event)
             return null
         }
 
-        // 트랜잭션이 없으면 그대로 발행
+        // If no transaction, publish as is
         return joinPoint.proceed()
     }
 

--- a/src/main/kotlin/org/sandbox/disx/outbox/OutboxKafkaPublisher.kt
+++ b/src/main/kotlin/org/sandbox/disx/outbox/OutboxKafkaPublisher.kt
@@ -81,7 +81,7 @@ class OutboxKafkaPublisher(
         }
     }
 
-    // TODO: 동적으로 수정
+    // TODO: Make this configurable dynamically
     private fun determineTopicFromEventType(eventType: String): String {
         return when {
             eventType.contains("Order", ignoreCase = true) -> "order-events"

--- a/src/main/kotlin/org/sandbox/disx/outbox/OutboxRepository.kt
+++ b/src/main/kotlin/org/sandbox/disx/outbox/OutboxRepository.kt
@@ -3,27 +3,27 @@ package org.sandbox.disx.outbox
 interface OutboxRepository {
 
     /**
-     * 이벤트 저장 (트랜잭션 내에서 호출됨)
+     * Save event (called within transaction)
      */
     fun save(event: OutboxEvent)
 
     /**
-     * 처리 대기 중인 이벤트 조회
+     * Find pending events
      */
     fun findPendingEvents(limit: Int = 100): List<OutboxEvent>
 
     /**
-     * 이벤트 상태 업데이트
+     * Update event status
      */
     fun updateStatus(eventId: String, status: OutboxStatus)
 
     /**
-     * 마지막 처리한 이벤트 ID 조회
+     * Get last processed event ID
      */
     fun getLastProcessedEventId(): String?
 
     /**
-     * 특정 ID 이후의 대기 중인 이벤트 조회
+     * Find pending events after specific ID
      */
     fun findPendingEventsAfterId(lastEventId: String?, limit: Int = 100): List<OutboxEvent>
 }

--- a/src/main/kotlin/org/sandbox/disx/outbox/OutboxService.kt
+++ b/src/main/kotlin/org/sandbox/disx/outbox/OutboxService.kt
@@ -19,7 +19,7 @@ class OutboxService(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     /**
-     * 도메인 이벤트를 Outbox에 저장
+     * Save domain event to Outbox
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun handleDomainEvent(event: BaseDomainEvent) {

--- a/src/test/kotlin/org/sandbox/disx/core/events/BaseDomainEventTest.kt
+++ b/src/test/kotlin/org/sandbox/disx/core/events/BaseDomainEventTest.kt
@@ -16,7 +16,7 @@ class BaseDomainEventTest {
     ) : BaseDomainEvent(aggregateId, eventId, occurredAt)
 
     @Test
-    fun `이벤트 생성시 기본값이 올바르게 설정되는지 테스트`() {
+    fun `test that default values are set correctly when creating an event`() {
         val aggregateId = "test-aggregate-123"
         val event = TestDomainEvent(aggregateId)
         
@@ -27,7 +27,7 @@ class BaseDomainEventTest {
     }
 
     @Test
-    fun `이벤트 생성시 커스텀 값이 올바르게 설정되는지 테스트`() {
+    fun `test that custom values are set correctly when creating an event`() {
         val aggregateId = "test-aggregate-456"
         val customEventId = "custom-event-id"
         val customOccurredAt = Instant.now().minusSeconds(10)
@@ -40,14 +40,14 @@ class BaseDomainEventTest {
     }
 
     @Test
-    fun `getEventType이 올바른 클래스명을 반환하는지 테스트`() {
+    fun `test that getEventType returns the correct class name`() {
         val event = TestDomainEvent("test-aggregate")
         
         assertEquals("TestDomainEvent", event.getEventType())
     }
 
     @Test
-    fun `toString이 올바른 형식으로 출력되는지 테스트`() {
+    fun `test that toString outputs in the correct format`() {
         val aggregateId = "test-aggregate"
         val eventId = "test-event-id"
         val occurredAt = Instant.parse("2024-01-01T00:00:00Z")
@@ -59,7 +59,7 @@ class BaseDomainEventTest {
     }
 
     @Test
-    fun `같은 eventId를 가진 이벤트들은 동등해야 함`() {
+    fun `events with the same eventId should be equal`() {
         val eventId = "same-event-id"
         val event1 = TestDomainEvent("aggregate1", eventId)
         val event2 = TestDomainEvent("aggregate2", eventId)
@@ -69,7 +69,7 @@ class BaseDomainEventTest {
     }
 
     @Test
-    fun `다른 eventId를 가진 이벤트들은 동등하지 않아야 함`() {
+    fun `events with different eventIds should not be equal`() {
         val event1 = TestDomainEvent("aggregate1", "event-id-1")
         val event2 = TestDomainEvent("aggregate1", "event-id-2")
         
@@ -78,7 +78,7 @@ class BaseDomainEventTest {
     }
 
     @Test
-    fun `대량의 이벤트 생성 성능 테스트`() {
+    fun `bulk event creation performance test`() {
         val eventCount = 100000
         val aggregateId = "performance-test-aggregate"
         
@@ -88,37 +88,37 @@ class BaseDomainEventTest {
             }
         }
         
-        println("대량 이벤트 생성 - 이벤트 수: $eventCount, 실행 시간: ${executionTime}ms")
-        println("평균 생성 시간: ${executionTime.toDouble() / eventCount}ms/event")
+        println("Bulk event creation - Event count: $eventCount, Execution time: ${executionTime}ms")
+        println("Average creation time: ${executionTime.toDouble() / eventCount}ms/event")
         
-        // 성능 검증: 100,000개 이벤트를 1초 이내에 생성 가능해야 함
-        assertTrue(executionTime < 1000, "이벤트 생성이 너무 느립니다: ${executionTime}ms")
+        // Performance validation: Should be able to create 100,000 events within 1 second
+        assertTrue(executionTime < 1000, "Event creation is too slow: ${executionTime}ms")
     }
 
     @Test
-    fun `이벤트 ID 유니크성 테스트`() {
+    fun `event ID uniqueness test`() {
         val eventCount = 10000
         val events = (1..eventCount).map { TestDomainEvent("aggregate-$it") }
         val uniqueEventIds = events.map { it.eventId }.toSet()
         
-        assertEquals(eventCount, uniqueEventIds.size, "생성된 이벤트 ID가 모두 유니크해야 합니다")
+        assertEquals(eventCount, uniqueEventIds.size, "All generated event IDs should be unique")
     }
 
     @Test
-    fun `이벤트 생성 시간 순서 테스트`() {
+    fun `event creation time order test`() {
         val events = mutableListOf<TestDomainEvent>()
         
         repeat(100) {
             events.add(TestDomainEvent("aggregate-$it"))
-            Thread.sleep(1) // 1ms 대기로 시간 차이 보장
+            Thread.sleep(1) // 1ms wait to ensure time difference
         }
         
-        // 생성 시간이 순차적으로 증가하는지 확인
+        // Check if creation times are in sequential order
         for (i in 1 until events.size) {
             assertTrue(
                 events[i].occurredAt.isAfter(events[i-1].occurredAt) || 
                 events[i].occurredAt.equals(events[i-1].occurredAt),
-                "이벤트 생성 시간이 순서대로 되어있지 않습니다"
+                "Event creation times are not in order"
             )
         }
     }

--- a/src/test/kotlin/org/sandbox/disx/core/events/BaseDomainEventTest.kt
+++ b/src/test/kotlin/org/sandbox/disx/core/events/BaseDomainEventTest.kt
@@ -1,0 +1,125 @@
+package org.sandbox.disx.core.events
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class BaseDomainEventTest {
+
+    private class TestDomainEvent(
+        aggregateId: String,
+        eventId: String = UUID.randomUUID().toString(),
+        occurredAt: Instant = Instant.now()
+    ) : BaseDomainEvent(aggregateId, eventId, occurredAt)
+
+    @Test
+    fun `이벤트 생성시 기본값이 올바르게 설정되는지 테스트`() {
+        val aggregateId = "test-aggregate-123"
+        val event = TestDomainEvent(aggregateId)
+        
+        assertEquals(aggregateId, event.aggregateId)
+        assertTrue(event.eventId.isNotEmpty())
+        assertTrue(event.occurredAt.isBefore(Instant.now().plusSeconds(1)))
+        assertTrue(event.occurredAt.isAfter(Instant.now().minusSeconds(1)))
+    }
+
+    @Test
+    fun `이벤트 생성시 커스텀 값이 올바르게 설정되는지 테스트`() {
+        val aggregateId = "test-aggregate-456"
+        val customEventId = "custom-event-id"
+        val customOccurredAt = Instant.now().minusSeconds(10)
+        
+        val event = TestDomainEvent(aggregateId, customEventId, customOccurredAt)
+        
+        assertEquals(aggregateId, event.aggregateId)
+        assertEquals(customEventId, event.eventId)
+        assertEquals(customOccurredAt, event.occurredAt)
+    }
+
+    @Test
+    fun `getEventType이 올바른 클래스명을 반환하는지 테스트`() {
+        val event = TestDomainEvent("test-aggregate")
+        
+        assertEquals("TestDomainEvent", event.getEventType())
+    }
+
+    @Test
+    fun `toString이 올바른 형식으로 출력되는지 테스트`() {
+        val aggregateId = "test-aggregate"
+        val eventId = "test-event-id"
+        val occurredAt = Instant.parse("2024-01-01T00:00:00Z")
+        
+        val event = TestDomainEvent(aggregateId, eventId, occurredAt)
+        val expectedString = "TestDomainEvent(aggregateId=test-aggregate, eventId=test-event-id, occurredAt=2024-01-01T00:00:00Z)"
+        
+        assertEquals(expectedString, event.toString())
+    }
+
+    @Test
+    fun `같은 eventId를 가진 이벤트들은 동등해야 함`() {
+        val eventId = "same-event-id"
+        val event1 = TestDomainEvent("aggregate1", eventId)
+        val event2 = TestDomainEvent("aggregate2", eventId)
+        
+        assertEquals(event1, event2)
+        assertEquals(event1.hashCode(), event2.hashCode())
+    }
+
+    @Test
+    fun `다른 eventId를 가진 이벤트들은 동등하지 않아야 함`() {
+        val event1 = TestDomainEvent("aggregate1", "event-id-1")
+        val event2 = TestDomainEvent("aggregate1", "event-id-2")
+        
+        assertNotEquals(event1, event2)
+        assertNotEquals(event1.hashCode(), event2.hashCode())
+    }
+
+    @Test
+    fun `대량의 이벤트 생성 성능 테스트`() {
+        val eventCount = 100000
+        val aggregateId = "performance-test-aggregate"
+        
+        val executionTime = kotlin.system.measureTimeMillis {
+            repeat(eventCount) {
+                TestDomainEvent(aggregateId)
+            }
+        }
+        
+        println("대량 이벤트 생성 - 이벤트 수: $eventCount, 실행 시간: ${executionTime}ms")
+        println("평균 생성 시간: ${executionTime.toDouble() / eventCount}ms/event")
+        
+        // 성능 검증: 100,000개 이벤트를 1초 이내에 생성 가능해야 함
+        assertTrue(executionTime < 1000, "이벤트 생성이 너무 느립니다: ${executionTime}ms")
+    }
+
+    @Test
+    fun `이벤트 ID 유니크성 테스트`() {
+        val eventCount = 10000
+        val events = (1..eventCount).map { TestDomainEvent("aggregate-$it") }
+        val uniqueEventIds = events.map { it.eventId }.toSet()
+        
+        assertEquals(eventCount, uniqueEventIds.size, "생성된 이벤트 ID가 모두 유니크해야 합니다")
+    }
+
+    @Test
+    fun `이벤트 생성 시간 순서 테스트`() {
+        val events = mutableListOf<TestDomainEvent>()
+        
+        repeat(100) {
+            events.add(TestDomainEvent("aggregate-$it"))
+            Thread.sleep(1) // 1ms 대기로 시간 차이 보장
+        }
+        
+        // 생성 시간이 순차적으로 증가하는지 확인
+        for (i in 1 until events.size) {
+            assertTrue(
+                events[i].occurredAt.isAfter(events[i-1].occurredAt) || 
+                events[i].occurredAt.equals(events[i-1].occurredAt),
+                "이벤트 생성 시간이 순서대로 되어있지 않습니다"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/sandbox/disx/core/events/EventBusPerformanceTest.kt
+++ b/src/test/kotlin/org/sandbox/disx/core/events/EventBusPerformanceTest.kt
@@ -1,0 +1,136 @@
+package org.sandbox.disx.core.events
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EventBusSimpleTest {
+
+    private class TestEvent(
+        aggregateId: String,
+        val data: String = "test-data",
+        eventId: String = UUID.randomUUID().toString(),
+        occurredAt: Instant = Instant.now()
+    ) : BaseDomainEvent(aggregateId, eventId, occurredAt)
+
+    private class TestEventHandler : EventHandler<TestEvent> {
+        val processedCount = AtomicLong(0)
+        
+        override suspend fun handle(event: TestEvent) {
+            processedCount.incrementAndGet()
+        }
+        
+        override fun getEventType(): Class<TestEvent> = TestEvent::class.java
+    }
+
+    // 테스트용 간단한 EventBus 구현체
+    private class TestEventBusImpl : EventBus {
+        private val handlers = mutableMapOf<Class<out BaseDomainEvent>, MutableList<EventHandler<out BaseDomainEvent>>>()
+        
+        override fun <T : BaseDomainEvent> publish(event: T) {
+            runBlocking {
+                getHandlersForEvent(event::class.java).forEach { handler ->
+                    @Suppress("UNCHECKED_CAST")
+                    (handler as EventHandler<BaseDomainEvent>).handle(event)
+                }
+            }
+        }
+        
+        override suspend fun <T : BaseDomainEvent> publishAsync(event: T) {
+            getHandlersForEvent(event::class.java).forEach { handler ->
+                @Suppress("UNCHECKED_CAST")
+                (handler as EventHandler<BaseDomainEvent>).handle(event)
+            }
+        }
+        
+        override fun <T : BaseDomainEvent> publishBatch(events: List<T>) {
+            runBlocking {
+                events.forEach { publishAsync(it) }
+            }
+        }
+        
+        override suspend fun <T : BaseDomainEvent> publishBatchAsync(events: List<T>) {
+            events.forEach { publishAsync(it) }
+        }
+        
+        fun <T : BaseDomainEvent> registerHandler(eventType: Class<T>, handler: EventHandler<T>) {
+            handlers.computeIfAbsent(eventType) { mutableListOf() }
+                .add(handler as EventHandler<out BaseDomainEvent>)
+        }
+        
+        private fun getHandlersForEvent(eventType: Class<out BaseDomainEvent>): List<EventHandler<out BaseDomainEvent>> {
+            return handlers[eventType] ?: emptyList()
+        }
+    }
+
+    @Test
+    fun `이벤트 버스 기본 동작 테스트`() {
+        val eventBus = TestEventBusImpl()
+        val handler = TestEventHandler()
+        eventBus.registerHandler(TestEvent::class.java, handler)
+        
+        val event = TestEvent("test-aggregate")
+        eventBus.publish(event)
+        
+        assertEquals(1, handler.processedCount.get())
+    }
+
+    @Test
+    fun `배치 이벤트 발행 테스트`() {
+        val eventBus = TestEventBusImpl()
+        val handler = TestEventHandler()
+        eventBus.registerHandler(TestEvent::class.java, handler)
+        
+        val events = listOf(
+            TestEvent("aggregate-1"),
+            TestEvent("aggregate-2"),
+            TestEvent("aggregate-3")
+        )
+        
+        eventBus.publishBatch(events)
+        
+        assertEquals(3, handler.processedCount.get())
+    }
+
+    @Test
+    fun `비동기 이벤트 발행 테스트`() = runBlocking {
+        val eventBus = TestEventBusImpl()
+        val handler = TestEventHandler()
+        eventBus.registerHandler(TestEvent::class.java, handler)
+        
+        val event = TestEvent("test-aggregate")
+        eventBus.publishAsync(event)
+        
+        assertEquals(1, handler.processedCount.get())
+    }
+
+    @Test
+    fun `핸들러가 없는 이벤트 발행 테스트`() {
+        val eventBus = TestEventBusImpl()
+        val event = TestEvent("test-aggregate")
+        
+        // 예외가 발생하지 않아야 함
+        eventBus.publish(event)
+        assertTrue(true)
+    }
+
+    @Test
+    fun `여러 핸들러 등록 테스트`() {
+        val eventBus = TestEventBusImpl()
+        val handler1 = TestEventHandler()
+        val handler2 = TestEventHandler()
+        
+        eventBus.registerHandler(TestEvent::class.java, handler1)
+        eventBus.registerHandler(TestEvent::class.java, handler2)
+        
+        val event = TestEvent("test-aggregate")
+        eventBus.publish(event)
+        
+        assertEquals(1, handler1.processedCount.get())
+        assertEquals(1, handler2.processedCount.get())
+    }
+}

--- a/src/test/kotlin/org/sandbox/disx/core/events/EventHandlerTest.kt
+++ b/src/test/kotlin/org/sandbox/disx/core/events/EventHandlerTest.kt
@@ -1,0 +1,99 @@
+package org.sandbox.disx.core.events
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EventHandlerTest {
+
+    private class TestEvent(
+        aggregateId: String,
+        val data: String = "test-data",
+        eventId: String = UUID.randomUUID().toString(),
+        occurredAt: Instant = Instant.now()
+    ) : BaseDomainEvent(aggregateId, eventId, occurredAt)
+
+    private class CountingEventHandler : EventHandler<TestEvent> {
+        val handledCount = AtomicInteger(0)
+
+        override suspend fun handle(event: TestEvent) {
+            handledCount.incrementAndGet()
+        }
+
+        override fun getEventType(): Class<TestEvent> = TestEvent::class.java
+    }
+
+    private class ExceptionThrowingHandler : EventHandler<TestEvent> {
+        val attemptCount = AtomicInteger(0)
+
+        override suspend fun handle(event: TestEvent) {
+            attemptCount.incrementAndGet()
+            throw RuntimeException("Test exception")
+        }
+
+        override fun getEventType(): Class<TestEvent> = TestEvent::class.java
+    }
+
+    @Test
+    fun `이벤트 핸들러 기본 동작 테스트`() = runBlocking {
+        val handler = CountingEventHandler()
+        val event = TestEvent("test-aggregate", "test-data")
+
+        handler.handle(event)
+
+        assertEquals(1, handler.handledCount.get())
+        assertEquals(TestEvent::class.java, handler.getEventType())
+    }
+
+    @Test
+    fun `여러 이벤트 순차 처리 테스트`() = runBlocking {
+        val handler = CountingEventHandler()
+        val eventCount = 10
+
+        repeat(eventCount) { i ->
+            val event = TestEvent("aggregate-$i", "data-$i")
+            handler.handle(event)
+        }
+
+        assertEquals(eventCount, handler.handledCount.get())
+    }
+
+    @Test
+    fun `예외 발생 핸들러 테스트`() = runBlocking {
+        val handler = ExceptionThrowingHandler()
+        val event = TestEvent("test-aggregate")
+
+        try {
+            handler.handle(event)
+            assertTrue(false, "예외가 발생해야 합니다")
+        } catch (e: RuntimeException) {
+            assertEquals("Test exception", e.message)
+            assertEquals(1, handler.attemptCount.get())
+        }
+    }
+
+    @Test
+    fun `이벤트 타입 확인 테스트`() {
+        val handler = CountingEventHandler()
+        assertEquals(TestEvent::class.java, handler.getEventType())
+    }
+
+    @Test
+    fun `동일한 핸들러로 다른 이벤트 처리 테스트`() = runBlocking {
+        val handler = CountingEventHandler()
+        
+        val event1 = TestEvent("aggregate-1", "data-1")
+        val event2 = TestEvent("aggregate-2", "data-2")
+        val event3 = TestEvent("aggregate-3", "data-3")
+
+        handler.handle(event1)
+        handler.handle(event2)
+        handler.handle(event3)
+
+        assertEquals(3, handler.handledCount.get())
+    }
+}


### PR DESCRIPTION
## 📌 개발 이유
Disx 프레임워크 적용 시 `BaseDomainEvent`, `EventBus`, `EventHandler` 등 핵심 클래스들이 누락되어 컴파일 에러가 발생했습니다.

## 💻 수정 사항
- `BaseDomainEvent`: 모든 도메인 이벤트의 기본 클래스 추가 (aggregateId, eventId, occurredAt 포함)
- `EventBus`: 이벤트 발행을 위한 인터페이스 추가 (동기/비동기, 단일/배치 발행 지원)
- `EventHandler<T>`: 이벤트 처리를 위한 제네릭 인터페이스 추가
- 기존 `KafkaEventBus` 구현체와 호환되도록 메서드 시그니처 맞춤

## 🧪 테스트 방법
```bash
./gradlew compileKotlin
```
- 컴파일 성공 확인
- GitTree 프로젝트에서 해당 클래스들 import 가능한지 확인

## ⛳️ 고민한 점 || 궁금한 점
- 기존 outbox 패턴과의 호환성 유지
- 불필요한 DefaultEventBus, EventPublisher 등은 제거하고 최소한의 인터페이스만 추가
- 분산 락 기능은 요구사항이 아니므로 제외
